### PR TITLE
Much simpler/safer deploy preview by specifying app name

### DIFF
--- a/.github/workflows/pr_close.yml
+++ b/.github/workflows/pr_close.yml
@@ -9,14 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - uses: dawidd6/action-download-artifact@v2
-        with:
-          search_artifacts: true
-          name: app-pr${{ github.event.pull_request.number }}
       - name: Destroy preview app
-        id: destroy
         run: |
-          app_name="$(jq -r .Name < app.json)"
-          flyctl apps destroy -y $app_name
+          flyctl apps destroy -y "setcookie-staging-${{ github.events.pull_request.number }}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/pr_open.yml
+++ b/.github/workflows/pr_open.yml
@@ -8,24 +8,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - uses: dawidd6/action-download-artifact@v2
-        with:
-          search_artifacts: true
-          if_no_artifact_found: ignore
-          name: app-pr${{ github.event.pull_request.number }}
       - name: Deploy preview app
-        id: deploy
         run: |
-          test app.json || flyctl apps create --generate-name -j > app.json
-          app_name="$(jq -r .Name < app.json)"
-          echo "app=$app_name" >> $GITHUB_OUTPUT
-          flyctl deploy --remote-only -a $app_name -e APP_ENV=staging
+          app_name="setcookie-staging-${{ github.event.pull_request.number }}"
+          flyctl apps list | grep "$app_name" || flyctl apps create "$app_name"
+          flyctl deploy --remote-only -a "$app_name" -e APP_ENV=staging
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: app-pr${{ github.event.pull_request.number }}
-          path: app.json
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: find-comment
@@ -40,4 +29,4 @@ jobs:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           body: >
-            Your deploy preview can be found at https://${{ steps.deploy.outputs.app }}.fly.dev.
+            Your deploy preview can be found at https://setcookie-staging-${{ github.event.pull_request.number }}.fly.dev.


### PR DESCRIPTION
After reading https://www.legitsecurity.com/blog/github-actions-that-open-the-door-to-cicd-pipeline-attacks, decided to make things much simpler and specify an app name based on the PR number.