### PR TITLE
Retrieve issue number from workflow step

### DIFF
--- a/.github/workflows/deploy_preview_comment.yml
+++ b/.github/workflows/deploy_preview_comment.yml
@@ -8,18 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Find PR number
+        id: number
+        run: |
+          number=$(curl -s ${{ github.event.workflow_run.jobs_url }} |
+            jq -r '.jobs[0].steps[] | select(.name | contains("Deploy preview")) | .name' |
+            sed 's/^.*#//')
+          echo "number=$number" >> $GITHUB_OUTPUT
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: find-comment
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.number.outputs.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Your deploy preview
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v2
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.number.outputs.number }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: replace
           body: >
-            Your deploy preview can be found at https://setcookie-staging-${{ github.event.workflow_run.pull_requests[0].number }}.fly.dev.
+            Your deploy preview can be found at https://setcookie-staging-${{ steps.number.outputs.number }}.fly.dev.

--- a/.github/workflows/pr_open.yml
+++ b/.github/workflows/pr_open.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - name: Deploy preview app
+      - name: "Deploy preview app #${{ github.event.pull_request.number }}"
         run: |
           app_name="setcookie-staging-${{ github.event.pull_request.number }}"
           flyctl apps list | grep "$app_name" || flyctl apps create "$app_name"


### PR DESCRIPTION
`github.event.workflow_run.pull_requests` is empty for forks. The proper solution would be to use workflow artifacts, but we can read the workflow output from the API.