### PR TITLE
add option to set cookie from JS call with fetch()

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -29,7 +29,6 @@ if (isset($_POST['name'], $_POST['value'])) {
     $httpOnly = (isset($_POST['httponly']) && $_POST['httponly'] === 'on');
     $expires = $app->expires();
     $samesite = $app->samesite();
-    $isFetch = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'fetch';
 
     try {
         if (empty($name) || empty($value)) {
@@ -88,11 +87,6 @@ if (isset($_POST['name'], $_POST['value'])) {
 
         setcookie($name, $value, $opts);
         $message = 'Sent header: <code>' . $app->getSentHeader() . '</code>';
-        if($isFetch) { 
-            header('Content-type: application/json');
-            echo json_encode(['existing_cookies' => $_COOKIE, 'set_cookie_header' => $app->getSentHeader()]);
-            exit;
-        }
     } catch (Exception $ex) {
         $error = $ex->getMessage();
     }
@@ -118,8 +112,6 @@ function displayUrl($url, $main) {
 
     return '<b class="url">' . $formatted . '</b> <i>(' . implode(', ', $facts) . ')</i>';
 }
-
-
 
 ?>
 <!doctype html>

--- a/public/index.php
+++ b/public/index.php
@@ -29,6 +29,7 @@ if (isset($_POST['name'], $_POST['value'])) {
     $httpOnly = (isset($_POST['httponly']) && $_POST['httponly'] === 'on');
     $expires = $app->expires();
     $samesite = $app->samesite();
+    $isFetch = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'fetch';
 
     try {
         if (empty($name) || empty($value)) {
@@ -87,6 +88,11 @@ if (isset($_POST['name'], $_POST['value'])) {
 
         setcookie($name, $value, $opts);
         $message = 'Sent header: <code>' . $app->getSentHeader() . '</code>';
+        if($isFetch) { 
+            header('Content-type: application/json');
+            echo json_encode(['existing_cookies' => $_COOKIE, 'set_cookie_header' => $app->getSentHeader()]);
+            exit;
+        }
     } catch (Exception $ex) {
         $error = $ex->getMessage();
     }
@@ -112,6 +118,8 @@ function displayUrl($url, $main) {
 
     return '<b class="url">' . $formatted . '</b> <i>(' . implode(', ', $facts) . ')</i>';
 }
+
+
 
 ?>
 <!doctype html>

--- a/public/index.php
+++ b/public/index.php
@@ -231,6 +231,13 @@ if (isset($_POST['name'], $_POST['value'])) {
         <p>Will result in the following cookie: <samp /></p>
         <input type="submit" />
       </form>
+      <p>Credentials:
+      <label><input type="radio" name="credentials" value="same-origin" checked />same-origin</label> 
+      <label><input type="radio" name="credentials" value="include" />include</label>
+      <label><input type="radio" name="credentials" value="omit" />omit</label>
+      <small><a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials">See MDN docs for fetch()#Include credentials</a> </small>
+      </p>
+      <button onClick="callFetch()">Call fetch()</button>
 
       <footer>
         <p><small>Created by <a href="https://cmbuckley.co.uk">Chris Buckley</a> for <a href="https://stackoverflow.com/questions/18492576/share-cookie-between-subdomain-and-domain">this Stack Overflow question</a>. <a href="https://github.com/cmbuckley/setcookie.net">View the source here</a>.</small></p>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -97,9 +97,13 @@ function callFetch() {
     body: data,
     credentials
   })
-    .then(_res => {
-      console.info('fetch() returned');
-      document.querySelector('a.reload').click()
-      console.info('Reloading cookie box');
+    .then(async function(res) {
+      console.info('fetch() returned',res);
+      const resText = await res.text();
+      const parsedRes = new DOMParser().parseFromString(resText, 'text/html');
+      const articleHtml = parsedRes.querySelector('article').innerHTML;
+      console.info('parsed response html', articleHtml);
+      document.querySelector('article').innerHTML = articleHtml;
+      console.info('Updated displayed cookie info');
     });
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -95,14 +95,11 @@ function callFetch() {
   fetch('/', {
     method: 'POST',
     body: data,
-    headers: {
-      'X-Requested-With': 'fetch',
-    },
     credentials
   })
     .then(_res => {
       console.info('fetch() returned');
-      // document.querySelector('a.reload').click()
+      document.querySelector('a.reload').click()
       console.info('Reloading cookie box');
     });
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -91,13 +91,12 @@ function callFetch() {
   }
   const credentials = document.querySelector('input[name=credentials]:checked').value
 
-  const fetchParams = {
+  console.info(`Calling fetch('/', ${JSON.stringify({method: 'POST', body: data.toString(), credentials},null, "\t")})` );
+  fetch('/', {
     method: 'POST',
     body: data,
     credentials
-  };
-  console.info(`Calling fetch('/', ${JSON.stringify(fetchParams)})` );
-  fetch('/', fetchParams)
+  })
     .then(_res => {
       console.info('fetch() returned');
       document.querySelector('a.reload').click()

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -95,11 +95,14 @@ function callFetch() {
   fetch('/', {
     method: 'POST',
     body: data,
+    headers: {
+      'X-Requested-With': 'fetch',
+    },
     credentials
   })
     .then(_res => {
       console.info('fetch() returned');
-      document.querySelector('a.reload').click()
+      // document.querySelector('a.reload').click()
       console.info('Reloading cookie box');
     });
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -82,3 +82,25 @@ if (document.cookie) {
       }
   }
 }
+
+function callFetch() {
+  const data = new URLSearchParams();
+  const formElement = document.querySelector('form');
+  for (const pair of new FormData(formElement)) {
+    data.append(pair[0], pair[1]);
+  }
+  const credentials = document.querySelector('input[name=credentials]:checked').value
+
+  const fetchParams = {
+    method: 'POST',
+    body: data,
+    credentials
+  };
+  console.info(`Calling fetch('/', ${JSON.stringify(fetchParams)})` );
+  fetch('/', fetchParams)
+    .then(_res => {
+      console.info('fetch() returned');
+      document.querySelector('a.reload').click()
+      console.info('Reloading cookie box');
+    });
+}


### PR DESCRIPTION
Closes #29 

### Rationale for adding this feature
Cookie setting behaviour is different when request is made with JS. Especially can get tricky with HttpOnly, credential or god forbid crossdomain calls 😅 
To simplify and allow convenient way to debug different browsers with different set ups.

### Changes Summary
- radio select button for `credential` property
- Link to MDN docs
- a button to "Call Fetch()"
1.  Form to string format (e.g `name=lo&value=u&path=%2F&dom=none&ss=notset` )
2. Calls fetch() with final form and `credentials` param
3. Output executed command to console
4. Reload cookies panel after server response