### PR TITLE
add section about Storage Access API required for third-party cookies…

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -148,6 +148,15 @@ function displayUrl($url, $main) {
         See also some <a href="https://<?= $main; ?>/quirks/">known browser quirks</a>.
       </p>
 
+      <p>
+        Implicit Third-party cookies are <a href="https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/" target="_blank">fully blocked</a>
+        by WebKit as of iOS 13.4 and Safari 13.1, so this site is not expected to be able to set cookies if embeded in an iframe in a third-party.
+        The linked article explains that calling `document.requestStorageAccess();` is necessary to request permission to use cookies in this context.
+        <div id="hasStorageAccessResult"></div>
+        <button onClick="doRequestStorageAccess()">Request storage access</button>
+        <div id="requestStorageAccessResult"></div>
+      </p>
+
       <article>
         <a class="reload" href="" title="Reload">↻</a>
 <?php

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -113,3 +113,28 @@ function callFetch() {
     }
   });
 }
+
+function doRequestStorageAccess() {
+  let resultDiv = document.querySelector('#requestStorageAccessResult');
+  resultDiv.innerHTML = 'Requesting...';
+  document.requestStorageAccess().then(
+    () => {
+      resultDiv.innerHTML = 'Cookie access granted';
+    },
+    () => {
+      resultDiv.innerHTML = 'Cookie access denied';
+    },
+  );
+}
+
+window.addEventListener('load', function() {
+  let resultDiv = document.querySelector('#hasStorageAccessResult');
+  document.hasStorageAccess().then(
+    (hasAccess) => {
+      resultDiv.innerHTML = "<b>hasStorageAccess result: </b>" + hasAccess.toString();
+    },
+    function (reason) {
+      resultDiv.innerHTML = "<b>hasStorageAccess failed with: </b>" + reason.toString();
+    }
+  );
+});


### PR DESCRIPTION
… by WebKit/Safari

See
https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/.

This allows testing if cookies work with and without using the Storage Access API.